### PR TITLE
Add LoRaWAN support and refactor LoRa EMB core (remove transmitData)

### DIFF
--- a/C++/examples/lora_emb_rx_test/lora_emb_rx_test.cpp
+++ b/C++/examples/lora_emb_rx_test/lora_emb_rx_test.cpp
@@ -3,97 +3,80 @@
 #include "hardware/gpio.h"
 #include "MeloperoPerpetuo.h"
 
-// Main function
 int main() {
     stdio_init_all();  // Initialize all standard IO
 
     MeloperoPerpetuo melopero;
-
-    melopero.init();  // Initialize the board and peripherals
+    melopero.init();  // Initialize board peripherals
 
     melopero.led_init();
     melopero.blink_led(2, 500);
 
+    // RGB LED test sequence
     melopero.enablelWs2812(true);
-
-    melopero.setWs2812Color(255, 0, 0, 0.2);  
-    sleep_ms(500);  
-
-    melopero.setWs2812Color(0, 255, 0, 0.2);  
-    sleep_ms(500);  
-
-    melopero.setWs2812Color(0, 0, 255, 0.2);  
-    sleep_ms(500);  
-    
-    // Turn off the RGB LED
+    melopero.setWs2812Color(255, 0, 0, 0.2);
+    sleep_ms(300);
+    melopero.setWs2812Color(0, 255, 0, 0.2);
+    sleep_ms(300);
+    melopero.setWs2812Color(0, 0, 255, 0.2);
+    sleep_ms(300);
     melopero.enablelWs2812(false);
 
+    // Request device ID
     melopero.sendCmd(0x01);
-    sleep_ms(500);
-    printf("response to deviceId\n");
+    sleep_ms(300);
+    printf("Response to device ID:\n");
     melopero.printResponse();
 
-    
-    // LoRaEMB operating mode configuration
-    melopero.stopNetwork();
-    sleep_ms(500);
-    printf("response to stopNetwork\n");
-    melopero.printResponse();
-    
-    melopero.setNetworkPreferences(false, false, false);
-    sleep_ms(500);
-    printf("response to setNetworkPreferences\n");
-    melopero.printResponse();
+    // LoRa EMB configuration (must match the transmitter)
+    auto cfg = melopero.getEMBConfig();
+    cfg.power    = 0x0A;                   // TX power step
+    cfg.channel  = 1;                      // Channel index
+    cfg.sf       = SPREADING_FACTOR_7;     // Spreading factor (SF7..SF12)
+    cfg.bw       = BANDWIDTH_125;          // Bandwidth (125 or 250 kHz)
+    cfg.cr       = CODING_RATE_4_5;        // Coding rate (4/5..4/8)
+    cfg.net_addr = 0x1234;                 // Network address (must match TX)
+    cfg.energy   = ENERGY_SAVE_MODE_ALWAYS_ON;  // Receiver always active
+    melopero.setEMBConfig(cfg);
 
-    melopero.setOutputPower(0x0a);  // Example power level
-    sleep_ms(500);
-    printf("response to setOutputPower\n");
-    melopero.printResponse();
+    if (melopero.startLoRaEMB(false) != TxStatus::Ok) {
+        printf("Failed to start LoRa EMB (invalid configuration)\n");
+        return 1;
+    }
 
-    melopero.setOperatingChannel(1, SPREADING_FACTOR_7, BANDWIDTH_125, CODING_RATE_4_5);  // Example channel
-    sleep_ms(500);
-    printf("response to setOperatingChannel\n");
-    melopero.printResponse();
-    
-    melopero.setNetworkAddress(0x1235);  // Example network address
-    sleep_ms(500);
-    printf("response to setNetworkAddress\n");
-    melopero.printResponse();
+    printf("LoRa EMB RX started. Waiting for incoming packets...\n");
 
-    uint8_t network_id[] = {0x00, 0x01};  // Example network ID
-    melopero.setNetworkId(network_id, sizeof(network_id));
-    sleep_ms(500);
-    printf("response to setNetworkId\n");
-    melopero.printResponse();
+    // Optional battery status check
+    if (melopero.isCharging()) {
+        printf("Battery is charging.\n");
+    } else if (melopero.isFullyCharged()) {
+        printf("Battery is fully charged.\n");
+    }
 
-    melopero.setEnergySaveMode(ENERGY_SAVE_MODE_ALWAYS_ON);
-    sleep_ms(500);
-    printf("response to setEnergySaveModeRxAlways\n");
-    melopero.printResponse();
+    // Main receive loop
+    while (true) {
+        if (melopero.checkRxFifo(1000)) {
+            printf("Data received (%u bytes):\n", (unsigned)melopero.responseLen);
 
-    melopero.startNetwork();
-    sleep_ms(500);
-    printf("response to startNetwork\n");
-    melopero.printResponse();
+            // Print the raw frame content as hexadecimal bytes
+            for (size_t i = 0; i < melopero.responseLen; ++i) {
+                printf("0x%02X ", melopero.response[i]);
+            }
+            printf("\n");
 
+            // Optional: check for multiple consecutive frames
+            while (melopero.checkRxFifo(50)) {
+                printf("Additional data received:\n");
+                for (size_t i = 0; i < melopero.responseLen; ++i) {
+                    printf("0x%02X ", melopero.response[i]);
+                }
+                printf("\n");
+            }
+        } else {
+            printf("No data in RX FIFO\n");
+        }
 
-//A battery must be connected; otherwise, 
-//the status will alternate between charging and fully charged.    
-int status = melopero.getChargerStatus();
-    if (melopero.isCharging()) { 
-        printf("The battery is charging.\n");
-    } 
-    else if (melopero.isFullyCharged()) {
-        printf("The battery is fully charged.\n");
-    } 
-    
-    while (1) {
-        
-
-        if(melopero.checkRxFifo(500)) {melopero.printResponse();}
-        else {printf("nothing in the rx fifo\n");}
-
-        sleep_ms(1000);
+        sleep_ms(500);
     }
 
     return 0;

--- a/C++/examples/lora_emb_tx_test/lora_emb_tx_test.cpp
+++ b/C++/examples/lora_emb_tx_test/lora_emb_tx_test.cpp
@@ -28,73 +28,33 @@ int main() {
 
     melopero.enablelWs2812(false);
 
-    // LoRaEMB operating mode configuration sequence:
-    // Stop Network
-    // Set Network preferences 
-    // Set Output power
-    // Set Operating channel
-    // Set Network address
-    // Set Network ID
-    // Set Energy save mode (the default value is TX_ONLY, set RX_ALWAYS)
-    // Start Network
+    // Prepare LoRa EMB configuration (optional; defaults are valid).
+auto cfg = melopero.getEMBConfig();
+cfg.power    = 0x0A;                  // TX power step
+cfg.channel  = 1;                     // logical channel
+cfg.sf       = SPREADING_FACTOR_7;    // SF7..SF12
+cfg.bw       = BANDWIDTH_125;         // 125/250 kHz
+cfg.cr       = CODING_RATE_4_5;       // 4/5..4/8
+cfg.net_addr = 0x1234;                // network address
+// cfg.net_id   = network_id;          // optional network ID pointer
+// cfg.net_id_len = sizeof(network_id);
+cfg.energy   = ENERGY_SAVE_MODE_TX_ONLY; // Always-on/RX-window/TX-only
+melopero.setEMBConfig(cfg);
 
-    melopero.stopNetwork();
-    sleep_ms(500);
-    printf("response to stopNetwork\n");
-    melopero.printResponse();
+// Start EMB mode (applies stored configuration atomically).
+if (melopero.startLoRaEMB(false) != TxStatus::Ok) {
+    printf("Failed to start LoRa EMB (invalid configuration)\n");
+    return 1;
+}
 
-    melopero.setNetworkPreferences(false, false, false);
-    sleep_ms(500);
-    printf("response to setNetworkPreferences\n");
-    melopero.printResponse();
+// Transmit loop: broadcast a small payload.
+while (true) {
+    const uint8_t data[] = {0x70, 0x71, 0x72, 0x73};
+    melopero.transmitEMB(data, sizeof(data));   // default dest=0xFFFF, options=0x0000
+    melopero.processExecStatus();               // prints execution status (and extras if present)
+    sleep_ms(6000);
+}
 
-    melopero.setOutputPower(0x0a);  // Example power level
-    sleep_ms(500);
-    printf("response to setOutputPower\n");
-    melopero.printResponse();
-    
-    melopero.setOperatingChannel(1, SPREADING_FACTOR_7, BANDWIDTH_125, CODING_RATE_4_5);  // Example channel
-    sleep_ms(500);
-    printf("response to setOperatingChannel\n");
-    melopero.printResponse();
-
-    melopero.setNetworkAddress(0x1234);  // Example network address
-    sleep_ms(500);
-    printf("response to setNetworkAddress\n");
-    melopero.printResponse();
-
-    uint8_t network_id[] = {0x00, 0x01};  // Example network ID
-    melopero.setNetworkId(network_id, sizeof(network_id));
-    sleep_ms(500);
-        printf("response to setNetworkId\n");
-        melopero.printResponse();
-
-     melopero.setEnergySaveMode(ENERGY_SAVE_MODE_TX_ONLY);
-    sleep_ms(500);
-    printf("response to setEnergySaveModeRxAlways\n");
-    melopero.printResponse();
-
-    //melopero.setEnergySaveModeRxAlways();
-    melopero.startNetwork();
-      sleep_ms(500);
-        printf("response to startNetwork\n");
-        melopero.printResponse();
-
-
-
-    while (1) {
-        uint8_t data[] = {0x70, 0x71, 0x72, 0x73};
-        
-        // Transmit data, by default to broadcast address 0xFFFF and options 0x0000
-        //to specify a different destination address or options, use:
-        // melopero.transmitData(data, sizeof(data), dest_addr, options);   
-        melopero.transmitData(data, sizeof(data));
-        
-        sleep_ms(500);
-        printf("response to transmitData\n");
-        melopero.printResponse();
-        sleep_ms(6000);
-    }
 
     return 0;
 }

--- a/C++/examples/lorawan_tx_test/lorawan_tx_test.cpp
+++ b/C++/examples/lorawan_tx_test/lorawan_tx_test.cpp
@@ -1,0 +1,48 @@
+#include <cstdio>
+#include "pico/stdlib.h"
+#include "MeloperoPerpetuo.h"
+
+int main() {
+    stdio_init_all();
+
+    MeloperoPerpetuo m;
+    m.init();
+
+    // LoRaWAN configuration (example: EU868, Class A, OTAA).
+    LoRaWANConfig lw = m.getLoRaWANConfig();
+    lw.region     = 0x00;  // module-specific mapping (e.g., EU868)
+    lw.klass      = 0x01;  // 0x01 = Class A, 0x00 = Class C
+    lw.adr        = true;
+    lw.auto_join  = true;
+    lw.use_otaa   = true;
+
+    // Fill OTAA credentials (replace with real values).
+    static const uint8_t JOINEUI[8] = { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
+    static const uint8_t DEVEUI[8]  = { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
+    static const uint8_t APPKEY[16] = {
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    };
+    lw.join_eui = JOINEUI;  lw.join_eui_len = 8;
+    lw.dev_eui  = DEVEUI;   lw.dev_eui_len  = 8;
+    lw.app_key  = APPKEY;   lw.app_key_len  = 16;
+
+    lw.default_fport     = 10;
+    lw.default_confirmed = false;
+
+    m.setLoRaWANConfig(lw);
+
+    // Starts LoRaWAN; performs auto-join if enabled.
+    if (m.startLoRaWAN(false) != TxStatus::Ok) {
+        printf("LoRaWAN start failed (invalid configuration or setup)\n");
+        return 1;
+    }
+
+    // Uplink loop.
+    while (true) {
+        const uint8_t app[] = { 0x01, 0x02, 0x03 };
+        m.transmitLoRaWAN(app, sizeof(app), /*fport_override*/-1, /*confirmed_override*/-1);
+        m.processExecStatus();  // prints execution status and optional fields if present
+        sleep_ms(5000);
+    }
+}

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -456,5 +456,40 @@ bool MeloperoPerpetuo::validateEMBConfig(const EMBConfig& cfg) const {
     return true;
 }
 
+TxStatus MeloperoPerpetuo::startLoRaEMB(bool force) {
+    // Skips unnecessary restart when already in EMB mode, configuration is applied,
+    // and no forced reapply is requested.
+    if (mode == NetworkMode::LoRaEMB && emb_config_pending == false && !force) {
+        return TxStatus::Ok;
+    }
+
+    // Validates the stored configuration before applying.
+    if (!validateEMBConfig(emb_config)) {
+        return TxStatus::InvalidArgs;
+    }
+
+    // Stops current network (required before changing radio options).
+    stopNetwork();
+
+    // Selects EMB as operating protocol (no LoRaWAN, no auto-join, no ADR).
+    setNetworkPreferences(false, false, false);
+
+    // Applies the stored EMB configuration (no start/stop inside setters).
+    setOutputPower(emb_config.power);
+    setOperatingChannel(emb_config.channel, emb_config.sf, emb_config.bw, emb_config.cr);
+    setNetworkAddress(emb_config.net_addr);
+    if (emb_config.net_id && emb_config.net_id_len) {
+        setNetworkId((uint8_t*)emb_config.net_id, emb_config.net_id_len);
+    }
+    setEnergySaveMode(emb_config.energy);
+
+    // Starts the network and marks configuration as synchronized.
+    startNetwork();
+    emb_config_pending = false;
+    mode = NetworkMode::LoRaEMB;
+
+    return TxStatus::Ok;
+}
+
 
 

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -6,6 +6,11 @@
 
 // Constructor
 MeloperoPerpetuo::MeloperoPerpetuo() {
+
+    // Initializes network state.
+    mode = NetworkMode::None;
+    network_running = false;
+    
 }
 
 // Destructor
@@ -144,11 +149,18 @@ void MeloperoPerpetuo::reset() {
 void MeloperoPerpetuo::stopNetwork() {
     uint8_t command = CMD_STOP_NETWORK;
     sendCmd(command);
+
+    // Marks network as stopped and clears the active mode.
+    network_running = false;
+    mode = NetworkMode::None;
 }
 
 void MeloperoPerpetuo::startNetwork() {
     uint8_t command = CMD_START_NETWORK;
     sendCmd(command);
+
+    // Marks network as running. The concrete mode is set by startLoRaEMB/LoRaWAN.
+    network_running = true;
 }
 
 void MeloperoPerpetuo::setNetworkPreferences(bool useLoRaWan, bool enableAutoJoining, bool enableADR) {
@@ -246,6 +258,12 @@ void MeloperoPerpetuo::enableFlowControl(uint32_t baudRate, bool enable) {
     uart_set_hw_flow(UART_PORT, enable, enable);
     uart_set_baudrate(UART_PORT, baudRate);
 }
+
+NetworkMode MeloperoPerpetuo::getMode() const {
+    // Returns the last known operating mode.
+    return mode;
+}
+
 
 
 // Charger Status Functions

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -11,6 +11,9 @@ MeloperoPerpetuo::MeloperoPerpetuo() {
     mode = NetworkMode::None;
     network_running = false;
 
+    // Marks default EMB configuration as pending until first apply.
+    emb_config_pending = true;
+
 }
 
 // Destructor
@@ -416,4 +419,42 @@ void MeloperoPerpetuo::processExecStatus() const {
         printf("ACK RSSI: %d dBm\n", ack_rssi);
     }
 }
+
+void MeloperoPerpetuo::setEMBConfig(const EMBConfig& cfg) {
+    // Stores configuration (application occurs on startLoRaEMB()).
+    emb_config = cfg;
+    emb_config_pending = true;  // Marks configuration as pending.
+}
+
+EMBConfig MeloperoPerpetuo::getEMBConfig() const {
+    // Returns a copy of the stored configuration.
+    return emb_config;
+}
+
+bool MeloperoPerpetuo::validateEMBConfig(const EMBConfig& cfg) const {
+    // TX power: generic safe ceiling (adjust to module limits if needed).
+    if (cfg.power > 0x14) return false;
+
+    // Channel: generic 1..16 (adjust if your module provides a different map).
+    if (cfg.channel < 1 || cfg.channel > 16) return false;
+
+    // Spreading Factor: SF7..SF12.
+    if (cfg.sf < SPREADING_FACTOR_7 || cfg.sf > SPREADING_FACTOR_12) return false;
+
+    // Bandwidth: 125 or 250 kHz.
+    if (cfg.bw != BANDWIDTH_125 && cfg.bw != BANDWIDTH_250) return false;
+
+    // Coding rate: 4/5..4/8.
+    if (cfg.cr < CODING_RATE_4_5 || cfg.cr > CODING_RATE_4_8) return false;
+
+    // Optional Network ID coherence.
+    if (cfg.net_id_len > 0 && cfg.net_id == nullptr) return false;
+
+    // Energy save mode: 0..2 (ALWAYS_ON, RX_WINDOW, TX_ONLY).
+    if (cfg.energy > ENERGY_SAVE_MODE_TX_ONLY) return false;
+
+    return true;
+}
+
+
 

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -100,6 +100,49 @@ void MeloperoPerpetuo::transmitEMB(const uint8_t* data,
     sendCmd(CMD_SEND_DATA, payload, idx);
 }
 
+TxStatus MeloperoPerpetuo::transmitLoRaWAN(const uint8_t* data, size_t len,
+                                           int fport_override,
+                                           int confirmed_override) {
+    // Ensures LoRaWAN mode is active prior to transmission.
+    if (mode != NetworkMode::LoRaWAN) {
+        return TxStatus::InvalidArgs; // Not running in LoRaWAN mode.
+    }
+
+    // Selects FPort and confirmed flag from overrides or defaults.
+    const uint8_t fport = (fport_override >= 0) ? (uint8_t)fport_override
+                                                : lorawan_config.default_fport;
+    const bool confirmed = (confirmed_override >= 0)
+                         ? (bool)confirmed_override
+                         : lorawan_config.default_confirmed;
+
+    // Builds the SEND_DATA payload for LoRaWAN:
+    // [options_H][options_L][Fport][app_data...]
+    // Use option bits per module doc; 0x0C00 is commonly "confirmed uplink".
+    uint16_t options = confirmed ? 0x0C00 : 0x0000;
+
+    // Length guard.
+    if (len + 3 > MAX_PACKET_SIZE) {
+        len = MAX_PACKET_SIZE - 3;
+    }
+
+    uint8_t payload[MAX_PACKET_SIZE];
+    size_t idx = 0;
+
+    payload[idx++] = (uint8_t)((options >> 8) & 0xFF);
+    payload[idx++] = (uint8_t)(options & 0xFF);
+    payload[idx++] = fport;
+
+    if (data && len > 0) {
+        memcpy(&payload[idx], data, len);
+        idx += len;
+    }
+
+    // Sends the frame to the module; response can be inspected via processExecStatus().
+    sendCmd(CMD_SEND_DATA, payload, idx);
+    return TxStatus::Ok;
+}
+
+
 
 
 // LoRa Helper Functions

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -264,6 +264,41 @@ NetworkMode MeloperoPerpetuo::getMode() const {
     return mode;
 }
 
+void MeloperoPerpetuo::setLoRaWANConfig(const LoRaWANConfig& cfg) {
+    // Stores configuration (application occurs on startLoRaWAN()).
+    lorawan_config = cfg;
+    lorawan_config_pending = true;  // Marks configuration as pending.
+}
+
+LoRaWANConfig MeloperoPerpetuo::getLoRaWANConfig() const {
+    // Returns a copy of the stored configuration.
+    return lorawan_config;
+}
+
+bool MeloperoPerpetuo::validateLoRaWANConfig(const LoRaWANConfig& cfg) const {
+    // Region range check (module-specific; adjust mapping as required).
+    if (cfg.region > 0x02) return false; // example: 0x00=EU868, 0x01=US915, 0x02=2.4GHz
+
+    // Class check: accepts 0x01 (A) or 0x00 (C).
+    if (cfg.klass != 0x01 && cfg.klass != 0x00) return false;
+
+    // FPort range (LoRaWAN spec: 1..223 for application traffic).
+    if (cfg.default_fport == 0 || cfg.default_fport > 223) return false;
+
+    if (cfg.use_otaa) {
+        // OTAA requires JoinEUI(8), DevEUI(8), AppKey(16).
+        if (cfg.join_eui_len != 8 || cfg.dev_eui_len != 8 || cfg.app_key_len != 16) return false;
+        if (!cfg.join_eui || !cfg.dev_eui || !cfg.app_key) return false;
+    } else {
+        // ABP requires NwkSKey(16) and AppSKey(16). DevAddr may be 0 only if assigned later.
+        if (cfg.nwk_skey_len != 16 || cfg.app_skey_len != 16) return false;
+        if (!cfg.nwk_skey || !cfg.app_skey) return false;
+        // No strict check on dev_addr here; leave to application policy or region rules.
+    }
+
+    return true;
+}
+
 
 
 // Charger Status Functions

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -523,5 +523,57 @@ TxStatus MeloperoPerpetuo::startLoRaEMB(bool force) {
     return TxStatus::Ok;
 }
 
+TxStatus MeloperoPerpetuo::startLoRaWAN(bool force) {
+    // Skips unnecessary restart when already in LoRaWAN mode, configuration is
+    // applied, and no forced reapply is requested.
+    if (mode == NetworkMode::LoRaWAN && lorawan_config_pending == false && !force) {
+        return TxStatus::Ok;
+    }
+
+    // Validates the stored configuration before applying.
+    if (!validateLoRaWANConfig(lorawan_config)) {
+        return TxStatus::InvalidArgs;
+    }
+
+    // Stops network before changing radio options and credentials.
+    stopNetwork();
+
+    // Selects LoRaWAN and options (auto-join and ADR).
+    setNetworkPreferences(true, lorawan_config.auto_join, lorawan_config.adr);
+
+    // Maps LoRaWAN class to energy mode: A -> RX_WINDOW, C -> ALWAYS_ON.
+    const uint8_t energy = (lorawan_config.klass == 0x01)
+                         ? ENERGY_SAVE_MODE_RX_WINDOW
+                         : ENERGY_SAVE_MODE_ALWAYS_ON;
+    setEnergySaveMode(energy);
+
+    // (Optional) Set region if a dedicated command exists in your module.
+    // Example placeholder:
+    // sendCmd(CMD_SET_REGION, &lorawan_config.region, 1);
+
+    // Apply credentials:
+    if (lorawan_config.use_otaa) {
+        // OTAA requires JoinEUI(8), DevEUI(8), AppKey(16).
+        // Replace the following placeholders with your concrete setters or sendCmd:
+        // setJoinEUI(lorawan_config.join_eui);
+        // setDevEUI(lorawan_config.dev_eui);
+        // setAppKey(lorawan_config.app_key);
+    } else {
+        // ABP requires DevAddr, NwkSKey, AppSKey (16B each).
+        // Replace placeholders with your concrete setters or sendCmd:
+        // setDevAddr(lorawan_config.dev_addr);
+        // setNwkSKey(lorawan_config.nwk_skey);
+        // setAppSKey(lorawan_config.app_skey);
+    }
+
+    // Starts network and marks configuration as synchronized.
+    startNetwork();
+    lorawan_config_pending = false;
+    mode = NetworkMode::LoRaWAN;
+
+    return TxStatus::Ok;
+}
+
+
 
 

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -10,7 +10,7 @@ MeloperoPerpetuo::MeloperoPerpetuo() {
     // Initializes network state.
     mode = NetworkMode::None;
     network_running = false;
-    
+
 }
 
 // Destructor
@@ -368,3 +368,52 @@ void MeloperoPerpetuo::printResponse() {
         printf("\n");
     }
 }
+
+// Maps an execution status byte to a human-readable description.
+static const char* exec_status_str(uint8_t s) {
+    switch (s) {
+        case 0x00: return "OK";
+        case 0x01: return "Generic error (network not started?)";
+        case 0x02: return "Invalid parameter";
+        case 0x03: return "Timeout (no ACK)";
+        case 0x04: return "No memory (reserved)";
+        case 0x05: return "Unsupported option";
+        case 0x06: return "Busy (channel activity, denied)";
+        case 0x07: return "Duty-cycle limit";
+        default:   return "Unknown status";
+    }
+}
+
+// Returns the first payload byte (execution status) if present; 0xFF otherwise.
+uint8_t MeloperoPerpetuo::getExecStatus() const {
+    if (responseLen >= 4) return response[3];
+    return 0xFF;
+}
+
+// Prints the execution status and, when available, retries and ACK RSSI fields.
+// This function assumes the last response follows the standard EBI frame layout:
+// [len_H][len_L][resp_id][status][optional...][checksum].
+void MeloperoPerpetuo::processExecStatus() const {
+    if (responseLen < 4) {
+        printf("No valid response (len=%u)\n", (unsigned)responseLen);
+        return;
+    }
+
+    const uint8_t status = response[3];
+    printf("Execution status: 0x%02X (%s)\n", status, exec_status_str(status));
+
+    // Best-effort parse of optional fields when present:
+    // - retries: 1 byte at payload index 1 (overall index 4)
+    // - ACK RSSI: 2 bytes (signed) at payload index 2..3 (overall 5..6)
+    size_t idx = 4;
+    if (idx < responseLen - 1) {
+        const uint8_t retries = response[idx++];
+        printf("Retries: %u\n", retries);
+    }
+    if (idx + 1 < responseLen - 1) {
+        const int16_t ack_rssi = (int16_t)((response[idx] << 8) | response[idx + 1]);
+        // idx += 2; // advance if more fields are parsed in the future
+        printf("ACK RSSI: %d dBm\n", ack_rssi);
+    }
+}
+

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -68,41 +68,38 @@ void MeloperoPerpetuo::sendCmd(uint8_t command, uint8_t* payload, size_t payload
 
 
 
-void MeloperoPerpetuo::transmitData(const uint8_t* data, size_t length, uint16_t dest_addr, uint16_t options) {
-    // Payload structure:
-    // [options_H][options_L][addr_H][addr_L][user_data...]
-    //
-    // Default values:
-    // options = 0x0000 → 00 00
-    // dest_addr = 0xFFFF → FF FF
-    //
-    // → Payload header: 00 00 FF FF + user data bytes
+void MeloperoPerpetuo::transmitEMB(const uint8_t* data,
+                                   size_t length,
+                                   uint16_t dest_addr,
+                                   uint16_t options) {
+    // Builds the EMB packet header and sends it through UART.
+    // Payload layout: [options_H][options_L][addr_H][addr_L][user_data...]
 
-    // Ensure the total packet does not exceed buffer size
     if (length + 4 > MAX_PACKET_SIZE) {
-        length = MAX_PACKET_SIZE - 4; // truncate safely
+        length = MAX_PACKET_SIZE - 4;  // Prevents overflow of internal buffer.
     }
 
     uint8_t payload[MAX_PACKET_SIZE];
     size_t idx = 0;
 
-    // Add "options" (big-endian)
+    // Add "options" field (big-endian).
     payload[idx++] = static_cast<uint8_t>((options >> 8) & 0xFF);
     payload[idx++] = static_cast<uint8_t>(options & 0xFF);
 
-    // Add destination address (big-endian)
+    // Add destination address (big-endian).
     payload[idx++] = static_cast<uint8_t>((dest_addr >> 8) & 0xFF);
     payload[idx++] = static_cast<uint8_t>(dest_addr & 0xFF);
 
-    // Copy user data after header
+    // Copy user data after the 4-byte header.
     if (data && length > 0) {
         memcpy(&payload[idx], data, length);
         idx += length;
     }
 
-    // Send the assembled payload through the standard LoRa command
+    // Sends the assembled frame to the module.
     sendCmd(CMD_SEND_DATA, payload, idx);
 }
+
 
 
 // LoRa Helper Functions

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -87,8 +87,13 @@ public:
 
     // LoRa Module Functions
     void sendCmd(uint8_t command, uint8_t* payload = nullptr, size_t payloadLen = 0);
-    //void transmitData(uint8_t* data, size_t length);
-    void transmitData(const uint8_t* data, size_t length, uint16_t dest_addr = 0xFFFF, uint16_t options   = 0x0000);
+    // Sends user data over LoRa EMB using the current configuration.
+    // The header format is [options_H][options_L][addr_H][addr_L][payload...].
+    // By default, 'dest_addr' = 0xFFFF (broadcast) and 'options' = 0x0000.
+    void transmitEMB(const uint8_t* data,
+                    size_t length,
+                    uint16_t dest_addr = 0xFFFF,
+                    uint16_t options   = 0x0000);
 
 
     void reset();

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -62,6 +62,20 @@
 // Network operating mode.
 enum class NetworkMode { None, LoRaEMB, LoRaWAN };
 
+// LoRa EMB runtime configuration. Defaults are valid at boot.
+struct EMBConfig {
+    uint8_t  power    = 0x0A;                  // TX power step (module-specific range)
+    uint8_t  channel  = 1;                     // Logical channel index
+    uint8_t  sf       = SPREADING_FACTOR_7;    // Spreading factor (SF7..SF12)
+    uint8_t  bw       = BANDWIDTH_125;         // Bandwidth (125/250 kHz)
+    uint8_t  cr       = CODING_RATE_4_5;       // Coding rate (4/5..4/8)
+    uint16_t net_addr = 0x1234;                // Network address (0x0000..0xFFFF)
+    const uint8_t* net_id = nullptr;           // Optional network ID pointer
+    size_t   net_id_len   = 0;                 // Optional network ID length
+    uint8_t  energy  = ENERGY_SAVE_MODE_TX_ONLY; // Energy save mode
+};
+
+
 
 class MeloperoPerpetuo {
 public:
@@ -95,6 +109,16 @@ public:
 
     // Returns the current network operating mode.
     NetworkMode getMode() const;
+
+    // Stores the given EMB configuration without applying it to the module.
+    void setEMBConfig(const EMBConfig& cfg);
+
+    // Returns the currently stored EMB configuration.
+    EMBConfig getEMBConfig() const;
+
+    // Validates the provided EMB configuration values.
+    bool validateEMBConfig(const EMBConfig& cfg) const;
+
 
 
     // Charger Status Functions
@@ -135,6 +159,11 @@ private:
     // Tracks the current network mode and whether the module is running.
     NetworkMode mode = NetworkMode::None;
     bool network_running = false;
+
+    // Last known EMB configuration (defaults at boot). Marked pending until applied.
+    EMBConfig emb_config{};
+    bool emb_config_pending = true;
+
 
 
     // Pins and Ports

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -116,6 +116,15 @@ public:
 
     void printResponse();
 
+    // Returns the execution status byte from the last response.
+    // Returns 0xFF if unavailable (e.g., response too short).
+    uint8_t getExecStatus() const;
+
+    // Prints the execution status and basic optional fields when present.
+    // Intended as a quick diagnostic after commands such as CMD_SEND_DATA.
+    void processExecStatus() const;
+
+
 private:
     // LoRa Private Methods
     uint8_t calculateChecksum(uint8_t* data, size_t length);

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -62,6 +62,10 @@
 // Network operating mode.
 enum class NetworkMode { None, LoRaEMB, LoRaWAN };
 
+// Generic return code for start/tx helpers.
+// 'InvalidArgs' is returned when the provided configuration is not valid.
+enum class TxStatus { Ok, InvalidArgs };
+
 // LoRa EMB runtime configuration. Defaults are valid at boot.
 struct EMBConfig {
     uint8_t  power    = 0x0A;                  // TX power step (module-specific range)
@@ -155,9 +159,7 @@ public:
     // Validates the provided EMB configuration values.
     bool validateEMBConfig(const EMBConfig& cfg) const;
 
-    // Generic return code for start/tx helpers.
-    // 'InvalidArgs' is returned when the provided configuration is not valid.
-    enum class TxStatus { Ok, InvalidArgs };
+ 
 
     // Starts LoRa EMB mode. When 'force' is true, the stored configuration is
     // reapplied even if it is already in sync. The sequence performs:

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -119,6 +119,16 @@ public:
     // Validates the provided EMB configuration values.
     bool validateEMBConfig(const EMBConfig& cfg) const;
 
+    // Generic return code for start/tx helpers.
+    // 'InvalidArgs' is returned when the provided configuration is not valid.
+    enum class TxStatus { Ok, InvalidArgs };
+
+    // Starts LoRa EMB mode. When 'force' is true, the stored configuration is
+    // reapplied even if it is already in sync. The sequence performs:
+    // Stop -> Select EMB preferences -> Apply stored EMBConfig -> Start.
+    TxStatus startLoRaEMB(bool force = false);
+
+
 
 
     // Charger Status Functions

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -111,6 +111,7 @@ public:
 
     // LoRa Module Functions
     void sendCmd(uint8_t command, uint8_t* payload = nullptr, size_t payloadLen = 0);
+    
     // Sends user data over LoRa EMB using the current configuration.
     // The header format is [options_H][options_L][addr_H][addr_L][payload...].
     // By default, 'dest_addr' = 0xFFFF (broadcast) and 'options' = 0x0000.
@@ -119,6 +120,12 @@ public:
                     uint16_t dest_addr = 0xFFFF,
                     uint16_t options   = 0x0000);
 
+    // Sends an uplink over LoRaWAN using the stored defaults unless overridden.
+    // 'fport_override' < 0 uses default_fport; 'confirmed_override' < 0 uses default_confirmed.
+    // Returns Ok when the frame has been queued to the module.
+    TxStatus transmitLoRaWAN(const uint8_t* data, size_t len,
+                            int fport_override = -1,
+                            int confirmed_override = -1);
 
     void reset();
     void stopNetwork();

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -59,6 +59,10 @@
 #define CODING_RATE_4_7 0x03
 #define CODING_RATE_4_8 0x04
 
+// Network operating mode.
+enum class NetworkMode { None, LoRaEMB, LoRaWAN };
+
+
 class MeloperoPerpetuo {
 public:
     MeloperoPerpetuo();
@@ -89,6 +93,10 @@ public:
     uint8_t response[256];  // Response buffer
     size_t responseLen;     // Length of the response
 
+    // Returns the current network operating mode.
+    NetworkMode getMode() const;
+
+
     // Charger Status Functions
     int getChargerStatus();
     bool isCharging();
@@ -113,8 +121,12 @@ private:
     uint8_t calculateChecksum(uint8_t* data, size_t length);
     void buildPacket(uint8_t messageId, uint8_t* payload, size_t payloadLen, uint8_t* packet, size_t* packetLen);
     
-    
     void enableFlowControl(uint32_t baudRate, bool enable);
+
+    // Tracks the current network mode and whether the module is running.
+    NetworkMode mode = NetworkMode::None;
+    bool network_running = false;
+
 
     // Pins and Ports
     static const int I2C_SDA_PIN = 24;

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -157,6 +157,13 @@ public:
     // Stop -> Select EMB preferences -> Apply stored EMBConfig -> Start.
     TxStatus startLoRaEMB(bool force = false);
 
+    // Starts LoRaWAN mode. When 'force' is true, the stored configuration is
+    // reapplied even if it is already in sync. The sequence performs:
+    // Stop -> Select LoRaWAN preferences -> Apply stored LoRaWANConfig -> Start.
+    TxStatus startLoRaWAN(bool force = false);
+
+
+
 
     // Stores the given LoRaWAN configuration without applying it to the module.
     void setLoRaWANConfig(const LoRaWANConfig& cfg);

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -75,6 +75,30 @@ struct EMBConfig {
     uint8_t  energy  = ENERGY_SAVE_MODE_TX_ONLY; // Energy save mode
 };
 
+// LoRaWAN runtime configuration. Defaults are usable but require credentials.
+struct LoRaWANConfig {
+    // Operation mode
+    bool     use_otaa        = true;   // true=OTAA, false=ABP
+    bool     adr             = true;   // Adaptive Data Rate
+    bool     auto_join       = true;   // OTAA: perform join automatically on start
+    uint8_t  klass           = 0x01;   // 0x01=Class A, 0x00=Class C
+    uint8_t  region          = 0x00;   // e.g., 0x00=EU868 (module-specific mapping)
+
+    // OTAA credentials (8+8+16 bytes). Pointers may be null when unused.
+    const uint8_t* join_eui  = nullptr; size_t join_eui_len = 0; // 8
+    const uint8_t* dev_eui   = nullptr; size_t dev_eui_len  = 0; // 8
+    const uint8_t* app_key   = nullptr; size_t app_key_len  = 0; // 16
+
+    // ABP credentials (DevAddr + 16+16 bytes). Keys may be null when unused.
+    uint32_t       dev_addr  = 0;
+    const uint8_t* nwk_skey  = nullptr; size_t nwk_skey_len = 0; // 16
+    const uint8_t* app_skey  = nullptr; size_t app_skey_len = 0; // 16
+
+    // Default uplink behavior
+    uint8_t  default_fport      = 1;    // Application port (1..223)
+    bool     default_confirmed  = false; // true=confirmed uplink, false=unconfirmed
+};
+
 
 
 class MeloperoPerpetuo {
@@ -134,6 +158,17 @@ public:
     TxStatus startLoRaEMB(bool force = false);
 
 
+    // Stores the given LoRaWAN configuration without applying it to the module.
+    void setLoRaWANConfig(const LoRaWANConfig& cfg);
+
+    // Returns the currently stored LoRaWAN configuration.
+    LoRaWANConfig getLoRaWANConfig() const;
+
+    // Validates the provided LoRaWAN configuration values.
+    bool validateLoRaWANConfig(const LoRaWANConfig& cfg) const;
+
+
+
 
 
     // Charger Status Functions
@@ -178,6 +213,11 @@ private:
     // Last known EMB configuration (defaults at boot). Marked pending until applied.
     EMBConfig emb_config{};
     bool emb_config_pending = true;
+
+    // Last known LoRaWAN configuration. Marked pending until applied.
+    LoRaWANConfig lorawan_config{};
+    bool lorawan_config_pending = true;
+
 
 
 


### PR DESCRIPTION
This pull request introduces LoRaWAN support and a complete refactor of the LoRa EMB implementation for the Melopero Perpetuo board.
It standardizes configuration handling, improves reliability, and simplifies network startup and transmission logic.

### **Main changes:**

**Added LoRaWAN support:**

- LoRaWANConfig structure (stores OTAA/ABP credentials, FPort, ADR, etc.)
- `setLoRaWANConfig()`, `getLoRaWANConfig()`, `validateLoRaWANConfig()`
- `startLoRaWAN(force)` to initialize and start a LoRaWAN session.
- `transmitLoRaWAN()` for uplink transmissions.

**Added LoRa EMB configuration system:**

- EMBConfig structure with runtime defaults.

- `setEMBConfig()`, `getEMBConfig()`, `validateEMBConfig()`

- `startLoRaEMB(force)` for automatic Stop → Configure → Start sequence.
- `transmitEMB()` replaces legacy `transmitData()`.

**Introduced NetworkMode and TxStatus enums.**
**Added execution status helpers:**

- `getExecStatus()`
- `processExecStatus()` (prints human-readable transmission result).




