### PR TITLE
Add tested LoRaWAN OTAA support and improve UART framing

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -14,6 +14,7 @@ pico_sdk_init()
 # Add subdirectories for each example
 add_subdirectory(examples/lora_emb_tx_test)
 add_subdirectory(examples/lora_emb_rx_test)
+add_subdirectory(examples/lorawan_tx_test)
 
 
 # Add the src directory

--- a/C++/examples/lorawan_tx_test/CMakeLists.txt
+++ b/C++/examples/lorawan_tx_test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Create an executable target for the transmitter test
+add_executable(lorawan_tx_test
+    lorawan_tx_test.cpp
+)
+
+# Link the MeloperoPerpetuo library and other dependencies
+target_link_libraries(lorawan_tx_test
+    MeloperoPerpetuo
+    pico_stdlib
+)
+
+# Enable USB output, disable UART output
+pico_enable_stdio_usb(lorawan_tx_test 1)
+pico_enable_stdio_uart(lorawan_tx_test 0)
+
+
+# Add this line to make the executable output as a UF2 file
+pico_add_extra_outputs(lorawan_tx_test)

--- a/C++/examples/lorawan_tx_test/lorawan_tx_test.cpp
+++ b/C++/examples/lorawan_tx_test/lorawan_tx_test.cpp
@@ -2,11 +2,37 @@
 #include "pico/stdlib.h"
 #include "MeloperoPerpetuo.h"
 
+// Helpers for printing EUI/key 
+static inline void print_hex_msb(const char* name, const uint8_t* v, size_t n) {
+    printf("%s (MSB): ", name);
+    for (size_t i = 0; i < n; ++i) printf("%02X", v[i]);
+    printf("\n");
+}
+static inline void print_hex_lsb(const char* name, const uint8_t* v, size_t n) {
+    printf("%s (LSB): ", name);
+    for (size_t i = 0; i < n; ++i) printf("%02X", v[n - 1 - i]);
+    printf("\n");
+}
+
+
 int main() {
     stdio_init_all();
 
     MeloperoPerpetuo m;
     m.init();
+    
+    // Print firmware version
+    sleep_ms(5000);
+
+        // --- Force full reset of LoRaWAN module before starting configuration ---
+    printf("Forcing LoRaWAN NVM reset...\n");
+    m.reset();          // CMD_RESET = 0x05
+    sleep_ms(1500);     // give it time to reboot fully
+    m.stopNetwork();    // extra safety to clear any pending state
+    sleep_ms(500);
+    printf("Reset complete. Continuing with configuration...\n");
+
+    m.printFirmwareVersion();
 
     // LoRaWAN configuration (example: EU868, Class A, OTAA).
     LoRaWANConfig lw = m.getLoRaWANConfig();
@@ -16,33 +42,46 @@ int main() {
     lw.auto_join  = true;
     lw.use_otaa   = true;
 
-    // Fill OTAA credentials (replace with real values).
-    static const uint8_t JOINEUI[8] = { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
-    static const uint8_t DEVEUI[8]  = { 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 };
+    // OTAA credentials generated from the TTN console (LoRaWAN 1.0.2, EU868).
+    static const uint8_t JOINEUI[8] = { 0x00, 0xC4, 0x5E, 0x72, 0x3A, 0x00, 0x79, 0x42 };
+    static const uint8_t DEVEUI[8]  = { 0x70, 0xB3, 0xD5, 0x7E, 0xD0, 0x07, 0x3F, 0x08 };
     static const uint8_t APPKEY[16] = {
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+        0xF2, 0x0E, 0xA1, 0xBE, 
+        0x2A, 0xFC, 0xAE, 0x4C, 
+        0x17, 0xCA, 0x9D, 0xFB, 
+        0xFC, 0xE8, 0xB9, 0xAA 
     };
+
+    print_hex_msb("DevEUI", DEVEUI, 8);
+    print_hex_lsb("DevEUI", DEVEUI, 8);
+    print_hex_msb("JoinEUI", JOINEUI, 8);
+    print_hex_lsb("JoinEUI", JOINEUI, 8);
+    print_hex_msb("AppKey", APPKEY, 16);
+
     lw.join_eui = JOINEUI;  lw.join_eui_len = 8;
     lw.dev_eui  = DEVEUI;   lw.dev_eui_len  = 8;
     lw.app_key  = APPKEY;   lw.app_key_len  = 16;
 
-    lw.default_fport     = 10;
-    lw.default_confirmed = false;
+    lw.default_fport     = 6;
+    lw.default_confirmed = true;
 
     m.setLoRaWANConfig(lw);
 
+    
+
     // Starts LoRaWAN; performs auto-join if enabled.
-    if (m.startLoRaWAN(false) != TxStatus::Ok) {
+    if (m.startLoRaWAN(true) != TxStatus::Ok) {
         printf("LoRaWAN start failed (invalid configuration or setup)\n");
         return 1;
     }
-
-    // Uplink loop.
+    
+    const uint8_t app[] = { 0xD0, 0xD1, 0xD2, 0xD3 };
     while (true) {
-        const uint8_t app[] = { 0x01, 0x02, 0x03 };
-        m.transmitLoRaWAN(app, sizeof(app), /*fport_override*/-1, /*confirmed_override*/-1);
-        m.processExecStatus();  // prints execution status and optional fields if present
-        sleep_ms(5000);
+        m.transmitLoRaWAN(app, sizeof(app), 6, 1);
+        m.processExecStatus();
+        sleep_ms(60000);
     }
+
 }
+
+

--- a/C++/src/MeloperoPerpetuo.cpp
+++ b/C++/src/MeloperoPerpetuo.cpp
@@ -2,6 +2,10 @@
 
 #define UART_PORT uart1
 
+// Forward declarations of helper functions
+static uint8_t send_prefs_try(MeloperoPerpetuo& m, uint8_t flags, int variant, uint8_t klass, uint8_t region);
+
+
 
 
 // Constructor
@@ -13,6 +17,9 @@ MeloperoPerpetuo::MeloperoPerpetuo() {
 
     // Marks default EMB configuration as pending until first apply.
     emb_config_pending = true;
+
+    // Marks default LoRaWAN configuration as pending until first apply.
+    lorawan_config_pending = true;
 
 }
 
@@ -60,10 +67,37 @@ void MeloperoPerpetuo::sendCmd(uint8_t command, uint8_t* payload, size_t payload
     // Build the packet with command and optional payload data
     buildPacket(command, payload, payloadLen, packetBuffer, &packetLen);
 
+    // DEBUG: dump del frame in uscita
+    printf("[TX] %02X bytes: ", (unsigned)packetLen);
+    for (size_t i = 0; i < packetLen; ++i) printf("%02X ", packetBuffer[i]);
+    printf("\n");
+
     // Transmit the packet via UART
     uart_write_blocking(UART_PORT, packetBuffer, packetLen);
 
-    checkRxFifo(200);
+    checkRxFifo(1000);
+}
+
+static inline void uart_flush_rx() {
+    while (uart_is_readable(UART_PORT)) (void)uart_getc(UART_PORT);
+}
+
+void MeloperoPerpetuo::sendCmdTimeout(uint8_t command, uint8_t* payload, size_t payloadLen, uint32_t timeout_ms) {
+    size_t totalPacketSize = payloadLen + 4;
+    uint8_t packetBuffer[totalPacketSize];
+    size_t packetLen;
+
+    buildPacket(command, payload, payloadLen, packetBuffer, &packetLen);
+
+    // DEBUG: dump del frame in uscita (con timeout)
+    printf("[TX][T=%u ms] %02X bytes: ", (unsigned)timeout_ms, (unsigned)packetLen);
+    for (size_t i = 0; i < packetLen; ++i) printf("%02X ", packetBuffer[i]);
+    printf("\n");
+
+    uart_flush_rx();
+    uart_write_blocking(UART_PORT, packetBuffer, packetLen);
+
+    checkRxFifo(timeout_ms);
 }
 
 
@@ -102,47 +136,88 @@ void MeloperoPerpetuo::transmitEMB(const uint8_t* data,
 
 TxStatus MeloperoPerpetuo::transmitLoRaWAN(const uint8_t* data, size_t len,
                                            int fport_override,
-                                           int confirmed_override) {
-    // Ensures LoRaWAN mode is active prior to transmission.
-    if (mode != NetworkMode::LoRaWAN) {
-        return TxStatus::InvalidArgs; // Not running in LoRaWAN mode.
-    }
+                                           int confirmed_override)
+{
+    if (mode != NetworkMode::LoRaWAN) return TxStatus::InvalidArgs;
 
-    // Selects FPort and confirmed flag from overrides or defaults.
     const uint8_t fport = (fport_override >= 0) ? (uint8_t)fport_override
                                                 : lorawan_config.default_fport;
     const bool confirmed = (confirmed_override >= 0)
                          ? (bool)confirmed_override
                          : lorawan_config.default_confirmed;
 
-    // Builds the SEND_DATA payload for LoRaWAN:
-    // [options_H][options_L][Fport][app_data...]
-    // Use option bits per module doc; 0x0C00 is commonly "confirmed uplink".
-    uint16_t options = confirmed ? 0x0C00 : 0x0000;
+    // Options: 0x0C00 = confirmed uplink, 0x0000 = unconfirmed.
+    const uint16_t options = confirmed ? 0x0C00 : 0x0000;
 
-    // Length guard.
-    if (len + 3 > MAX_PACKET_SIZE) {
-        len = MAX_PACKET_SIZE - 3;
-    }
+    // Cap payload length to avoid overrunning the internal buffer.
+    if (len + 3 > MAX_PACKET_SIZE) len = MAX_PACKET_SIZE - 3;
 
+    // Payload layout: [opt_H][opt_L][FPort][app_data...]
     uint8_t payload[MAX_PACKET_SIZE];
     size_t idx = 0;
+    payload[idx++] = (uint8_t)((options >> 8) & 0xFF); // 0x0C
+    payload[idx++] = (uint8_t)(options & 0xFF);        // 0x00
+    payload[idx++] = fport;                            // es. 0x01
+    if (data && len) { memcpy(&payload[idx], data, len); idx += len; }
 
-    payload[idx++] = (uint8_t)((options >> 8) & 0xFF);
-    payload[idx++] = (uint8_t)(options & 0xFF);
-    payload[idx++] = fport;
+    // Log TX in a human-readable form.
+    printf("[LoRaWAN] TX (confirmed=%d, fport=%u, bytes=%u)\n",
+           confirmed ? 1 : 0, fport, (unsigned)len);
 
-    if (data && len > 0) {
-        memcpy(&payload[idx], data, len);
-        idx += len;
+    // Use a long timeout (up to ~65 s) as the first TX may involve additional overhead.
+    sendCmdTimeout(CMD_SEND_DATA, payload, idx, 65000);
+
+    // The response frame may be fragmented or interleaved with other events:
+    // if it is not valid yet, try to collect more data for a few extra iterations.
+    auto is_send_resp = [this]() {
+        return (this->responseLen >= 4) && (this->response[2] == 0xD0);
+    };
+
+    if (!is_send_resp()) {
+        // extra attempts to collect the response
+        for (int i = 0; i < 6 && !is_send_resp(); ++i) {
+            // 6 * 1000ms = ~6s extra
+            checkRxFifo(1000);
+        }
     }
 
-    // Sends the frame to the module; response can be inspected via processExecStatus().
-    sendCmd(CMD_SEND_DATA, payload, idx);
-    return TxStatus::Ok;
+    // Dump raw response
+    printf("[LoRaWAN] SEND_DATA resp (%u bytes): ", (unsigned)this->responseLen);
+    for (size_t i = 0; i < this->responseLen; ++i) printf("%02X ", this->response[i]);
+    printf("\n");
+
+    
+
+// Expected layout: [len_H][len_L][0xD0][status][...][checksum]
+if (this->responseLen < 4 || this->response[2] != 0xD0) {
+    printf("No valid SEND_DATA response (id != 0xD0)\n");
+    return TxStatus::NoResponse;
 }
 
+const uint8_t status = this->response[3];
+// Optional fields (if any)
+int yy_present = (this->responseLen >= 5);
+int zz_present = (this->responseLen >= 6);
+uint8_t yy = yy_present ? this->response[4] : 0xFF;
+uint8_t zz = zz_present ? this->response[5] : 0xFF;
 
+printf("Execution status: 0x%02X", status);
+if (yy_present) printf(", YY=%u", (unsigned)yy);
+if (zz_present) printf(", ZZ=%s", (zz == 0x00 ? "ACK OK" : "ACK MISS/NA"));
+printf("\n");
+
+// Status Map -> TxStatus
+switch (status) {
+    case 0x00: return TxStatus::Ok;          // success
+    case 0x01: return TxStatus::Error;       // generic error
+    case 0x02: return TxStatus::InvalidArgs; // invalid parameter
+    case 0x03: return TxStatus::Timeout;     // timeout / no ACK received
+    case 0x05: return TxStatus::Unsupported; // unsupported option
+    case 0x06: return TxStatus::ChannelBusy; // busy / CAD denied
+    case 0x07: return TxStatus::DutyCycle;   // duty-cycle limit reached
+    default:   return TxStatus::Error;       // unknown status code
+}
+}
 
 
 // LoRa Helper Functions
@@ -207,26 +282,16 @@ void MeloperoPerpetuo::startNetwork() {
 }
 
 void MeloperoPerpetuo::setNetworkPreferences(bool useLoRaWan, bool enableAutoJoining, bool enableADR) {
-    uint8_t command = CMD_SET_NETWORK_PREFERENCES;
-    uint8_t payload = 0x00;
+    
 
-    // Set the network protocol (bit 7)
-    if (useLoRaWan) {
-        payload |= (1 << 7);  // Set bit 7 for LoRaWAN
-    }
+    uint8_t flags = 0;
+    flags |= (1<<7); // LoRaWAN
+    if (lorawan_config.auto_join) flags |= (1<<6);
+    if (lorawan_config.adr)       flags |= (1<<5);
 
-    // Set the Auto Joining option (bit 6)
-    if (enableAutoJoining) {
-        payload |= (1 << 6);  // Set bit 6 for Auto Joining
-    }
-
-    // Set the ADR option (bit 5)
-    if (enableADR) {
-        payload |= (1 << 5);  // Set bit 5 for ADR
-    }
-
-    // Send the command with the constructed payload
-    sendCmd(command, &payload, sizeof(payload));
+    uint8_t prefs_payload[3] = { flags, lorawan_config.region /*0x00 EU868?*/, lorawan_config.klass /*0x01 A, 0x00 C*/ };
+    sendCmd(CMD_SET_NETWORK_PREFERENCES, prefs_payload, sizeof(prefs_payload));
+    printf("[LoRaWAN] Set prefs(flags,region,class) -> status=0x%02X\n", getExecStatus());
 }
 
 
@@ -265,34 +330,49 @@ void MeloperoPerpetuo::setEnergySaveMode(uint8_t save_mode) {
 // UART Communication Functions
 
 bool MeloperoPerpetuo::checkRxFifo(uint32_t timeoutMs) {
-    responseLen = 0;  // Reset response length
-    memset(response, 0, sizeof(response));  // Clear the response buffer
-    uint32_t startTime = to_ms_since_boot(get_absolute_time());  // Get the current time
+    responseLen = 0;
+    memset(response, 0, sizeof(response));
+    uint32_t start = to_ms_since_boot(get_absolute_time());
 
-    while ((to_ms_since_boot(get_absolute_time()) - startTime) < timeoutMs) {
+    // Wait until at least one byte is available or timeout expires.
+    while ((to_ms_since_boot(get_absolute_time()) - start) < timeoutMs) {
+        if (uart_is_readable(UART_PORT)) break;
+        tight_loop_contents();
+    }
+    if (!uart_is_readable(UART_PORT)) return false;
+
+    // Read the 2-byte length header.
+    while (uart_is_readable(UART_PORT) && responseLen < 2) {
+        response[responseLen++] = uart_getc(UART_PORT);
+    }
+    if (responseLen < 2) return false;
+
+    const uint16_t total_len = ((uint16_t)response[0] << 8) | response[1];
+    if (total_len < 4 || total_len > sizeof(response)) return false;
+
+    while (responseLen < total_len) {
         if (uart_is_readable(UART_PORT)) {
-            return readRxFifo(response, &responseLen, sizeof(response));
+            response[responseLen++] = uart_getc(UART_PORT);
+        } else if ((to_ms_since_boot(get_absolute_time()) - start) > timeoutMs) {
+            break;
         }
     }
-
-    return false;  // Return false if no data was read before the timeout
+    return (responseLen == total_len);
 }
 
 
 
 bool MeloperoPerpetuo::readRxFifo(uint8_t* response, size_t* responseLen, size_t maxBufferSize) {
     size_t bytesRead = 0;
-
-    // Read as long as there is data in the UART FIFO and space in the buffer
     while (uart_is_readable(UART_PORT) && *responseLen < maxBufferSize) {
-        uint8_t byte = uart_getc(UART_PORT);  // Read one byte at a time
-        response[*responseLen] = byte;        // Store the byte in the response buffer
-        (*responseLen)++;                     // Increment the total byte count
+        uint8_t byte = uart_getc(UART_PORT);
+        response[*responseLen] = byte;
+        (*responseLen)++;
         bytesRead++;
     }
-
-    return bytesRead > 0;  // Return true if any bytes were read
+    return bytesRead > 0;
 }
+
 
 
 
@@ -342,6 +422,32 @@ bool MeloperoPerpetuo::validateLoRaWANConfig(const LoRaWANConfig& cfg) const {
     return true;
 }
 
+bool MeloperoPerpetuo::getFirmwareVersion(uint8_t out[4]) {
+    
+    // Try the dedicated firmware version command (may not be implemented on all revisions).
+    sendCmd(CMD_FIRMWARE_VERSION, nullptr, 0);
+
+    if (responseLen >= 8 && response[2] == 0x86) {
+        out[0] = response[3];
+        out[1] = response[4];
+        out[2] = response[5];
+        out[3] = response[6];
+        return true;
+    }
+
+    // If the command is not supported or the payload is too short, report FW as unavailable.
+    return false;
+}
+
+
+void MeloperoPerpetuo::printFirmwareVersion() {
+    uint8_t v[4] = {0};
+    if (getFirmwareVersion(v)) {
+        printf("FW: %02X %02X %02X %02X\n", v[0], v[1], v[2], v[3]);
+    } else {
+        printf("FW: <unavailable>\n");
+    }
+}
 
 
 // Charger Status Functions
@@ -567,56 +673,155 @@ TxStatus MeloperoPerpetuo::startLoRaEMB(bool force) {
 }
 
 TxStatus MeloperoPerpetuo::startLoRaWAN(bool force) {
-    // Skips unnecessary restart when already in LoRaWAN mode, configuration is
-    // applied, and no forced reapply is requested.
-    if (mode == NetworkMode::LoRaWAN && lorawan_config_pending == false && !force) {
+    // Skip restart if already configured and no force requested.
+    if (mode == NetworkMode::LoRaWAN && !lorawan_config_pending && !force)
         return TxStatus::Ok;
-    }
 
-    // Validates the stored configuration before applying.
-    if (!validateLoRaWANConfig(lorawan_config)) {
+    // Validate configuration.
+    if (!validateLoRaWANConfig(lorawan_config))
         return TxStatus::InvalidArgs;
-    }
 
-    // Stops network before changing radio options and credentials.
+    // Put module in a clean state.
+    reset();
+    sleep_ms(300);
     stopNetwork();
+    sleep_ms(100);
 
-    // Selects LoRaWAN and options (auto-join and ADR).
-    setNetworkPreferences(true, lorawan_config.auto_join, lorawan_config.adr);
+    // --- PREFS (0x25) ---
+    uint8_t flags = 0;
+    flags |= (1 << 7);
+    if (lorawan_config.auto_join) flags |= (1 << 6);
+    if (lorawan_config.adr)       flags |= (1 << 5);
 
-    // Maps LoRaWAN class to energy mode: A -> RX_WINDOW, C -> ALWAYS_ON.
-    const uint8_t energy = (lorawan_config.klass == 0x01)
-                         ? ENERGY_SAVE_MODE_RX_WINDOW
-                         : ENERGY_SAVE_MODE_ALWAYS_ON;
+    uint8_t prefs_ok = 0xFF;
+
+    const int variants[3] = {0, 1, 2};
+    const uint8_t classes_try[2] = { (uint8_t)0x01, (uint8_t)0x00 };
+    const uint8_t regions_try[4] = { lorawan_config.region, (uint8_t)0x00, (uint8_t)0x01, (uint8_t)0x02 };
+
+    for (int vi = 0; vi < 3; ++vi) {
+        int variant = variants[vi];
+        for (int ci = 0; ci < 2; ++ci) {
+            uint8_t klass_try = classes_try[ci];
+            for (int ri = 0; ri < 4; ++ri) {
+                uint8_t region_try = regions_try[ri];
+                uint8_t st = send_prefs_try(*this, flags, variant, klass_try, region_try);
+                sleep_ms(120);
+                if (st == 0x00) {
+                    printf("[PREFS] accepted variant=%d class=0x%02X region=0x%02X\n", variant, klass_try, region_try);
+                    prefs_ok = 0x00;
+                    goto PREFS_DONE;
+                }
+            }
+        }
+    }
+    PREFS_DONE:
+
+
+    // --- ENERGY (0x13) ---
+    const uint8_t energy = (lorawan_config.klass == 0x01) ?
+                        ENERGY_SAVE_MODE_RX_WINDOW : ENERGY_SAVE_MODE_ALWAYS_ON;
     setEnergySaveMode(energy);
+    printf("[LoRaWAN] Set energy -> 0x%02X\n", getExecStatus());
+    sleep_ms(120);
 
-    // (Optional) Set region if a dedicated command exists in your module.
-    // Example placeholder:
-    // sendCmd(CMD_SET_REGION, &lorawan_config.region, 1);
+    // --- KEYS (0x26): AppKey (0x01) e NwkKey (0x00), MSB order ---
+    if (lorawan_config.use_otaa && lorawan_config.app_key && lorawan_config.app_key_len == 16) {
 
-    // Apply credentials:
-    if (lorawan_config.use_otaa) {
-        // OTAA requires JoinEUI(8), DevEUI(8), AppKey(16).
-        // Replace the following placeholders with your concrete setters or sendCmd:
-        // setJoinEUI(lorawan_config.join_eui);
-        // setDevEUI(lorawan_config.dev_eui);
-        // setAppKey(lorawan_config.app_key);
-    } else {
-        // ABP requires DevAddr, NwkSKey, AppSKey (16B each).
-        // Replace placeholders with your concrete setters or sendCmd:
-        // setDevAddr(lorawan_config.dev_addr);
-        // setNwkSKey(lorawan_config.nwk_skey);
-        // setAppSKey(lorawan_config.app_skey);
+        // AppKey (selector 0x01)
+        {
+            uint8_t pl[1 + 16];
+            pl[0] = 0x01;
+            memcpy(&pl[1], lorawan_config.app_key, 16);
+            sendCmd(CMD_SET_NETWORK_SECURITY, pl, sizeof(pl));
+            printf("[KEY sel=0x01] AppKey MSB -> status=0x%02X\n", getExecStatus());
+        }
+
+        // NwkKey (selector 0x00)
+        {
+            uint8_t pl[1 + 16];
+            pl[0] = 0x00;
+            memcpy(&pl[1], lorawan_config.app_key, 16);
+            sendCmd(CMD_SET_NETWORK_SECURITY, pl, sizeof(pl));
+            printf("[KEY sel=0x00] NwkKey MSB -> status=0x%02X\n", getExecStatus());
+        }
+
+        sleep_ms(200);
     }
 
-    // Starts network and marks configuration as synchronized.
+
+
+
+
+    // --- PHYSICAL ADDRESS (0x20): JoinEUI(8) then DevEUI(8), already in LSB order ---
+    if (lorawan_config.use_otaa &&
+        lorawan_config.join_eui && lorawan_config.dev_eui &&
+        lorawan_config.join_eui_len == 8 && lorawan_config.dev_eui_len == 8) {
+
+        uint8_t phy[16];
+
+        // Values are passed as-is; the application must provide them in the format
+        // expected by the module (no implicit byte swapping is performed here).
+        memcpy(phy, lorawan_config.join_eui, 8);      // JoinEUI
+        memcpy(phy + 8, lorawan_config.dev_eui, 8);   // DevEUI
+
+        // Debug: print values as sent to the module.
+        printf("[DEBUG] JoinEUI direct: ");
+        for (int i = 0; i < 8; ++i) printf("%02X", phy[i]);
+        printf("\n");
+
+        printf("[DEBUG] DevEUI direct: ");
+        for (int i = 8; i < 16; ++i) printf("%02X", phy[i]);
+        printf("\n");
+
+        sendCmd(CMD_SET_PHYSICAL_ADDRESS, phy, sizeof(phy));
+        printf("[PHY 0x20] JoinEUI|DevEUI direct -> status=0x%02X\n", getExecStatus());
+        sleep_ms(200);
+    }
+
+
+
+
+
+
+
+    // Start the network (auto-join if enabled).
     startNetwork();
+    printf("[LoRaWAN] Start network -> status=0x%02X\n", getExecStatus());
+    sleep_ms(100);
+
+    // --- TEST: ask for network status ---
+    sendCmd(CMD_GET_NETWORK_STATUS, nullptr, 0);
+    printf("[LoRaWAN] Network status resp (%u bytes): ", (unsigned)this->responseLen);
+    for (size_t i = 0; i < this->responseLen; i++) printf("%02X ", this->response[i]);
+    printf("\n");
+
+    // Mark configuration as synced.
     lorawan_config_pending = false;
     mode = NetworkMode::LoRaWAN;
-
     return TxStatus::Ok;
 }
 
-
-
+// ------------------
+// Helper SET_NETWORK_PREFERENCES (0x25)
+// ------------------
+uint8_t send_prefs_try(MeloperoPerpetuo& m, uint8_t flags, int variant, uint8_t klass, uint8_t region) {
+    if (variant == 0) {
+        m.sendCmd(CMD_SET_NETWORK_PREFERENCES, &flags, 1);
+        printf("[PREFS] flags-only -> 0x%02X\n", m.getExecStatus());
+        return m.getExecStatus();
+    } else if (variant == 1) {
+        uint8_t p[3] = { flags, klass, region };
+        m.sendCmd(CMD_SET_NETWORK_PREFERENCES, p, sizeof(p));
+        printf("[PREFS] flags,class,region (class=0x%02X,region=0x%02X) -> 0x%02X\n",
+               klass, region, m.getExecStatus());
+        return m.getExecStatus();
+    } else {
+        uint8_t p[3] = { flags, region, klass };
+        m.sendCmd(CMD_SET_NETWORK_PREFERENCES, p, sizeof(p));
+        printf("[PREFS] flags,region,class (region=0x%02X,class=0x%02X) -> 0x%02X\n",
+               region, klass, m.getExecStatus());
+        return m.getExecStatus();
+    }
+}
 

--- a/C++/src/MeloperoPerpetuo.h
+++ b/C++/src/MeloperoPerpetuo.h
@@ -24,6 +24,17 @@
 #define CMD_SET_NETWORK_ID 0x22
 #define CMD_SET_ENERGY_SAVE_MODE 0x13
 #define CMD_SEND_DATA 0x50
+#define CMD_GET_NETWORK_STATUS        0x19
+
+
+// LoRaWAN-specific commands (from ebi_lora_rev_2.1)
+#define CMD_SET_PHYSICAL_ADDRESS   0x20  // payload: [JoinEUI(8)][DevEUI(8)]
+#define CMD_SET_NETWORK_SECURITY   0x26  // payload: [selector][value...]; 0x01=AppKey, 0x00=NwkKey
+
+// Device / firmware info (EBI-LoRa rev1.0.1-3)
+#define CMD_FIRMWARE_VERSION 0x06  // response: 0x86 + 4B version
+// Device / firmware info (fallback if 0x06 unsupported)
+#define CMD_DEVICE_INFO 0x01  // response: 0x81 + payload
 
 // Buffer sizes
 #define CMD_SIZE 64
@@ -62,9 +73,19 @@
 // Network operating mode.
 enum class NetworkMode { None, LoRaEMB, LoRaWAN };
 
-// Generic return code for start/tx helpers.
-// 'InvalidArgs' is returned when the provided configuration is not valid.
-enum class TxStatus { Ok, InvalidArgs };
+
+// High-level transmission result codes used by EMB and LoRaWAN helpers.
+enum class TxStatus : uint8_t {
+    Ok = 0,
+    InvalidArgs,
+    Error,
+    Timeout,
+    Unsupported,
+    ChannelBusy,
+    DutyCycle,
+    NoResponse
+};
+
 
 // LoRa EMB runtime configuration. Defaults are valid at boot.
 struct EMBConfig {
@@ -115,6 +136,7 @@ public:
 
     // LoRa Module Functions
     void sendCmd(uint8_t command, uint8_t* payload = nullptr, size_t payloadLen = 0);
+    void sendCmdTimeout(uint8_t command, uint8_t* payload, size_t payloadLen, uint32_t timeout_ms);
     
     // Sends user data over LoRa EMB using the current configuration.
     // The header format is [options_H][options_L][addr_H][addr_L][payload...].
@@ -142,6 +164,12 @@ public:
     void setEnergySaveMode(uint8_t save_mode);
     bool checkRxFifo(uint32_t timeoutMs);
     bool readRxFifo(uint8_t* response, size_t* responseLen, size_t maxBufferSize);
+
+    // Get firmware version as 4 bytes; returns true on success.
+    bool getFirmwareVersion(uint8_t out[4]);
+
+    // Print firmware version as "FW: XX XX XX XX".
+    void printFirmwareVersion();
 
     // rx buffer
     uint8_t response[256];  // Response buffer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+## [Unreleased]
+
+### Added
+- Extended `TxStatus` enumeration to cover additional LoRaWAN execution results
+  (generic error, timeout, unsupported option, channel busy, duty cycle limit, no response).
+- High-level `transmitLoRaWAN()` helper that builds the `0x50` SEND_DATA frame
+  as `[options_H][options_L][FPort][payload...]` and interprets the module response.
+- `sendCmdTimeout()` helper to send commands with a configurable timeout and
+  pre-TX RX FIFO flush.
+- Optional firmware query via `CMD_FIRMWARE_VERSION (0x06)` and
+  `printFirmwareVersion()` helper for diagnostics.
+- Debug logging for TX frames and raw responses to simplify serial tracing.
+
+### Changed
+- `checkRxFifo()` now assembles complete, length-prefixed frames
+  (`len_H`, `len_L`, payload, checksum) instead of reading raw bytes until timeout,
+  improving robustness when multiple responses are queued.
+- `startLoRaWAN()` now performs a complete configuration sequence:
+  - Sets network preferences (`0x25`) using flags, class and region.
+  - Sets energy save mode (`0x13`) according to LoRaWAN class.
+  - Programs security keys (`0x26`) and physical address (`0x20`)
+    from `LoRaWANConfig` (JoinEUI, DevEUI, AppKey).
+  - Starts the network (`0x31`) and queries network status (`0x19`).
+- `main.cpp` example updated to:
+  - Use JoinEUI, DevEUI and AppKey as provisioned in the TTN console.
+  - Configure LoRaWAN (EU868, Class A, OTAA, ADR, auto-join).
+  - Periodically send an uplink on the configured FPort and log execution status.
+
+### Fixed
+- Improved handling of SEND_DATA responses by checking the response ID and
+  mapping the execution status byte to `TxStatus`.
+- Reduced risk of mixing frames in the UART RX path thanks to length-based
+  frame reconstruction and RX FIFO flushing before long-timeout commands.
+
+


### PR DESCRIPTION
## Overview

This PR extends the **Melopero Perpetuo driver** with:

* a complete **LoRaWAN (OTAA) helper**,
* more robust **UART framing**,
* and an improved **end-to-end example**.

The updated example has been tested with **TTN (LoRaWAN 1.0.2, EU868)**, achieving a successful **OTAA join** and **periodic uplinks**.

---

## Changes

### 🔷 LoRaWAN Helper & Status Codes

* Extend `TxStatus` to cover new execution results:

  * timeout
  * generic error
  * unsupported option
  * channel busy
  * duty cycle
  * no response
* Add a high-level `transmitLoRaWAN()` that builds the **0x50 SEND_DATA** frame:

  * `options_H`, `options_L`
  * `FPort`
  * payload
* Parse the SEND_DATA response and map the execution status byte to `TxStatus`.

---

### 🔷 UART Framing & Command Handling

* Add `sendCmdTimeout()`:

  * sends a frame with configurable timeout
  * flushes RX FIFO before TX
* Improve `checkRxFifo()`:

  * now reads **length-prefixed frames** (`len_H`, `len_L`, …, checksum)
  * avoids “read until timeout”
  * handles back-to-back frames safely
* Add debug prints for:

  * outgoing frames
  * received responses
    to make serial troubleshooting easier.

---

### 🔷 LoRaWAN Setup Sequence

Added a complete `startLoRaWAN()` sequence:

* Configure network preferences (0x25): flags, class, region.
* Configure energy save mode (0x13):

  * Class A → RX window
  * Class C → always on
* Program security keys (0x26) and physical address (0x20) using:

  * JoinEUI
  * DevEUI
  * AppKey
    from `LoRaWANConfig`
* Start the network (0x31) and query network status (0x19).
* Optional firmware query:

  * `CMD_FIRMWARE_VERSION` (0x06)
  * helper `printFirmwareVersion()`.

---

### 🔷 Example Application

Updated `main.cpp`:

* Use JoinEUI, DevEUI and AppKey as provisioned in the TTN console.
* Configure LoRaWAN for:

  * EU868
  * Class A
  * OTAA
  * ADR enabled
  * auto-join
* Periodically send an uplink on the configured FPort.
* Log execution status for diagnostics.

---

## Testing

Tested on real hardware with **TTN**:

* **LoRaWAN 1.0.2**, EU868
* Successful OTAA join
* Periodic uplinks received correctly by TTN


